### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflow/main.yml
+++ b/.github/workflow/main.yml
@@ -6,7 +6,7 @@ name: Build and Publish Docker
     steps:
     - uses: actions/checkout@master
     - name: Publish to Docker Repository
-    uses: elgohr/Publish-Docker-Github-Action@master
+    uses: elgohr/Publish-Docker-Github-Action@v5
     with:
       name: subinghong/docker-githubaction
       username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-image-ubuntu-gui.yml
+++ b/.github/workflows/docker-image-ubuntu-gui.yml
@@ -9,7 +9,7 @@ jobs:
       shell: bash
       run: echo "release-version=$(echo ${GITHUB_SHA:0:8})" >> $GITHUB_OUTPUT
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         InstallGooglepinyin: 1
         env2: 1

--- a/.github/workflows/docker-image-ubuntu-sshd-tailscale.yml
+++ b/.github/workflows/docker-image-ubuntu-sshd-tailscale.yml
@@ -9,7 +9,7 @@ jobs:
       shell: bash
       run: echo "release-version=$(echo ${GITHUB_SHA:0:8})" >> $GITHUB_OUTPUT
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: subinghong/ubuntu-ssh
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-image-ubuntu-sshd.yml
+++ b/.github/workflows/docker-image-ubuntu-sshd.yml
@@ -9,7 +9,7 @@ jobs:
       shell: bash
       run: echo "release-version=$(echo ${GITHUB_SHA:0:8})" >> $GITHUB_OUTPUT
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: subinghong/ubuntu-ssh
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/novnc.yml
+++ b/.github/workflows/novnc.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: subinghong/ubuntu-ssh
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ubuntu_vsc.yml
+++ b/.github/workflows/ubuntu_vsc.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: subinghong/ubuntu_vsc
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore